### PR TITLE
revert: docs(version): move site to 2.5 (#237)

### DIFF
--- a/docs/APIs/indexMPS.md
+++ b/docs/APIs/indexMPS.md
@@ -7,4 +7,4 @@
   }
 </style>
 
-!!swagger-http https://api.swaggerhub.com/apis/rbheopenamt/mps/2.5.0!!
+!!swagger-http https://api.swaggerhub.com/apis/rbheopenamt/mps/2.4.0!!

--- a/docs/APIs/indexRPS.md
+++ b/docs/APIs/indexRPS.md
@@ -7,4 +7,4 @@
   }
 </style>
 
-!!swagger-http https://api.swaggerhub.com/apis/rbheopenamt/rps/2.5.0!!
+!!swagger-http https://api.swaggerhub.com/apis/rbheopenamt/rps/2.4.0!!

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -130,10 +130,10 @@ markdown_extensions:
   - toc:
       permalink: true
 extra_css:
-  - assets/stylesheets/branding.css
-  - assets/stylesheets/mermaid.css
-  - assets/stylesheets/index.css
-  - assets/stylesheets/videos.css
+  - assets\stylesheets\branding.css
+  - assets\stylesheets\mermaid.css
+  - assets\stylesheets\index.css
+  - assets\stylesheets\videos.css
 extra_javascript:
   - https://unpkg.com/mermaid/dist/mermaid.min.js
 plugins:
@@ -146,16 +146,16 @@ extra:
   version:
     provider: mike
   repoVersion:
-    mpsAPI: 2.5.0
-    rpsAPI: 2.5.0
-    oamtct: 2.5.0
-    rpc_go: 2.3.0
+    mpsAPI: 2.4.0
+    rpsAPI: 2.4.0
+    oamtct: 2.4.0
+    rpc_go: 2.2.0
     rpc_c: 2.0.0
-    ui_toolkit: 2.0.8
-    ui_toolkit_react: 2.0.7
-    ui_toolkit_angular: 4.0.1
+    ui_toolkit: 2.0.7
+    ui_toolkit_react: 2.0.4
+    ui_toolkit_angular: 3.0.2
   docsSite:
-    rapidVersion: 2.5
+    rapidVersion: 2.4
     ltsVersion: 2.0
   analytics:
     provider: google

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -130,10 +130,10 @@ markdown_extensions:
   - toc:
       permalink: true
 extra_css:
-  - assets\stylesheets\branding.css
-  - assets\stylesheets\mermaid.css
-  - assets\stylesheets\index.css
-  - assets\stylesheets\videos.css
+  - assets/stylesheets/branding.css
+  - assets/stylesheets/mermaid.css
+  - assets/stylesheets/index.css
+  - assets/stylesheets/videos.css
 extra_javascript:
   - https://unpkg.com/mermaid/dist/mermaid.min.js
 plugins:

--- a/site/versions.json
+++ b/site/versions.json
@@ -1,5 +1,4 @@
 [
-    {"version": "2.5", "title": "2.5", "aliases": []},
     {"version": "2.4", "title": "2.4", "aliases": []},
     {"version": "2.3", "title": "2.3", "aliases": []},
     {"version": "2.2", "title": "2.2", "aliases": []},


### PR DESCRIPTION
This reverts commit 4387d2fd01d608b948d2153c5c4e61644879b4c9.

revert: move site to 2.5

## PR Checklist
<!-- Please check if your PR fulfills the following requirements: -->

- [x] Leverages formatting as provided by https://squidfunk.github.io/mkdocs-material/reference/abbreviations/ 
- [x] Have viewed and verified edits in rendered form ensuring proper formatting

## What are you changing?
<!-- Please provide a short description of the updates that are in the PR -->


## Anything the reviewer should know when reviewing this PR?
