### PR TITLE
ci(gh-actions): resolve zizmor findings

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -23,5 +23,7 @@ jobs:
 
       - name: 'Checkout Repository'
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: 'Dependency Review'
         uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0

--- a/.github/workflows/mkdocs_build.yml
+++ b/.github/workflows/mkdocs_build.yml
@@ -37,6 +37,8 @@ jobs:
           egress-policy: audit
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.11"
@@ -46,7 +48,8 @@ jobs:
           pip install -r ./requirements.txt --require-hashes
           mkdocs build --strict
       #checkout the gh-pages branch
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      # credentials must persist here: the "Publish content" step pushes to gh-pages
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1 # zizmor: ignore[artipacked]
         if: ${{ github.ref == 'refs/heads/main' }}
         with:
           path: "to-be-published"
@@ -65,5 +68,5 @@ jobs:
           git config user.name github-actions
           git config user.email github-actions@github.com
           git add .
-          git commit -m "ci: ${{env.MESSAGE}}"
+          git commit -m "ci: $MESSAGE"
           git push origin gh-pages

--- a/.github/workflows/semantic.yml
+++ b/.github/workflows/semantic.yml
@@ -26,6 +26,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
+          persist-credentials: false
       - uses: wagoid/commitlint-github-action@b948419dd99f3fd78a6548d48f94e3df7f6bf3ed # v6.2.1
         with:
           configFile: .github/commitlint.config.cjs

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+---
+# Zizmor configuration. See https://docs.zizmor.sh/configuration/
+rules:
+  # Daily updates with no cooldown are intentional here. A version compromised
+  # at publish time can reach CI before it is yanked, but the blast radius is
+  # small: Dependabot PRs do not receive repository secrets by default and run
+  # with a read-only GITHUB_TOKEN.
+  dependabot-cooldown:
+    ignore:
+      - dependabot.yml


### PR DESCRIPTION
- Set persist-credentials: false on the actions/checkout steps in dependency-review, semantic, and the source checkout of mkdocs_build.
- Keep credentials on the gh-pages checkout in mkdocs_build, since the Publish content step commits and pushes to gh-pages with that token; suppress artipacked inline there instead.
- Use the MESSAGE env var directly in the publish shell instead of interpolating ${{ env.MESSAGE }} into the run block.
- Add .github/zizmor.yml to ignore dependabot-cooldown for the intentional daily, no-cooldown Dependabot schedules.

## PR Checklist
<!-- Please check if your PR fulfills the following requirements: -->

- [ ] Leverages formatting as provided by https://squidfunk.github.io/mkdocs-material/reference/abbreviations/ 
- [ ] Have viewed and verified edits in rendered form ensuring proper formatting

## What are you changing?
<!-- Please provide a short description of the updates that are in the PR -->


## Anything the reviewer should know when reviewing this PR?
